### PR TITLE
Add new Lotus releases

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -32,6 +32,13 @@ jobs:
         platform:
           - linux/amd64,linux/arm64
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+         tool-cache: false
+         android: true
+         dotnet: true
+         haskell: true
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -23,6 +23,7 @@ jobs:
           - v1.23.2
           - v1.23.3
           - v1.23.4-rc1
+          - v1.23.4-rc2
         net:
           - name: mainnet
             goflags: ''

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -24,6 +24,8 @@ jobs:
           - v1.23.3
           - v1.23.4-rc1
           - v1.23.4-rc2
+          - v1.24.0-rc1
+          - v1.25.0-rc1
         net:
           - name: mainnet
             goflags: ''


### PR DESCRIPTION
This PR does the following:
1. Fix the out of space issue
2. Add the latest releases v1.23.4-rc2, v1.24.0-rc1 and v1.25.0-rc1