### PR TITLE
Skip image build/push if it exists

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -35,25 +35,6 @@ jobs:
         platform:
           - linux/amd64,linux/arm64
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-         tool-cache: false
-         android: true
-         dotnet: true
-         haskell: true
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: filecoin-project/lotus
-          ref: ${{ matrix.version }}
-          path: lotus
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          platforms: ${{ matrix.platform }}
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -67,8 +48,39 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=lotus-${{ matrix.version }}-${{ matrix.net.name }}
+      - name: Check if image exists
+        id: checker
+        run: |
+          if ! docker manifest inspect ${{ steps.meta.outputs.tags }}
+          then
+            echo "IMAGE_EXISTS=false" >> $GITHUB_ENV
+          fi
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: env.IMAGE_EXISTS == 'false'
+        with:
+         tool-cache: false
+         android: true
+         dotnet: true
+         haskell: true
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: env.IMAGE_EXISTS == 'false'
+        with:
+          repository: filecoin-project/lotus
+          ref: ${{ matrix.version }}
+          path: lotus
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        if: env.IMAGE_EXISTS == 'false'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        if: env.IMAGE_EXISTS == 'false'
+        with:
+          platforms: ${{ matrix.platform }}
       - name: Build Lotus ${{ matrix.version }} ${{ matrix.net.name }}
         uses: docker/build-push-action@v4
+        if: env.IMAGE_EXISTS == 'false'
         env:
           REGISTRY_CACHE_REF: ghcr.io/${{ github.repository }}:cache
         with:


### PR DESCRIPTION
To avoid building images on every merge to main, check if image exists first and only build/push if absent.